### PR TITLE
Add GitHub Action for automatic GIF to PNG conversion

### DIFF
--- a/.github/workflows/convert-gifs.yml
+++ b/.github/workflows/convert-gifs.yml
@@ -50,7 +50,13 @@ jobs:
           CHANGED_GIFS=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}..HEAD | grep '\.gif$' || true)
         else
           # For pushes to main, check files in the last commit
-          CHANGED_GIFS=$(git diff --name-only HEAD~1..HEAD | grep '\.gif$' || true)
+          # Handle case where HEAD~1 doesn't exist (first commit)
+          if git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+            CHANGED_GIFS=$(git diff --name-only HEAD~1..HEAD | grep '\.gif$' || true)
+          else
+            # First commit - check all GIF files
+            CHANGED_GIFS=$(git ls-files | grep '\.gif$' || true)
+          fi
         fi
         
         if [ -z "$CHANGED_GIFS" ]; then

--- a/.github/workflows/convert-gifs.yml
+++ b/.github/workflows/convert-gifs.yml
@@ -1,0 +1,97 @@
+name: Convert GIFs to PNGs
+
+on:
+  pull_request:
+    paths:
+      - 'gen_1/*.gif'
+      - 'gen_2/*.gif'
+      - 'gen_keynotes/*.gif'
+  push:
+    branches: [main]
+    paths:
+      - 'gen_1/*.gif'
+      - 'gen_2/*.gif' 
+      - 'gen_keynotes/*.gif'
+
+jobs:
+  convert-gifs:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        
+    - name: Install ImageMagick
+      run: sudo apt-get update && sudo apt-get install -y imagemagick
+      
+    - name: Convert new/modified GIFs to PNGs
+      run: |
+        # Function to convert GIF to PNG
+        convert_gif_to_png() {
+          local gif_file="$1"
+          local dir_name=$(dirname "$gif_file")
+          local base_name=$(basename "$gif_file" .gif)
+          local png_file="$dir_name/malmons_APNG/${base_name}.png"
+          
+          # Create output directory if it doesn't exist
+          mkdir -p "$dir_name/malmons_APNG"
+          
+          # Convert first frame of GIF to PNG
+          convert "$gif_file[0]" "$png_file"
+          echo "Converted $gif_file to $png_file"
+        }
+        
+        # Get list of modified GIF files
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          # For pull requests, check files changed in the PR
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          CHANGED_GIFS=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}..HEAD | grep '\.gif$' || true)
+        else
+          # For pushes to main, check files in the last commit
+          CHANGED_GIFS=$(git diff --name-only HEAD~1..HEAD | grep '\.gif$' || true)
+        fi
+        
+        if [ -z "$CHANGED_GIFS" ]; then
+          echo "No GIF files were modified"
+          exit 0
+        fi
+        
+        echo "Converting modified GIF files:"
+        echo "$CHANGED_GIFS"
+        
+        # Convert each modified GIF
+        echo "$CHANGED_GIFS" | while read gif_file; do
+          if [ -f "$gif_file" ]; then
+            convert_gif_to_png "$gif_file"
+          fi
+        done
+        
+    - name: Check for changes
+      id: verify-changed-files
+      run: |
+        if [ -n "$(git status --porcelain)" ]; then
+          echo "changed=true" >> $GITHUB_OUTPUT
+        else
+          echo "changed=false" >> $GITHUB_OUTPUT
+        fi
+        
+    - name: Commit PNG files
+      if: steps.verify-changed-files.outputs.changed == 'true'
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add gen_*/malmons_APNG/*.png
+        git commit -m "Auto-convert GIFs to PNGs
+
+        🤖 Generated with GitHub Actions
+        
+        Co-Authored-By: GitHub Actions <action@github.com>" || exit 0
+        
+    - name: Push changes
+      if: steps.verify-changed-files.outputs.changed == 'true'
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: ${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
 ## Summary
  - Adds automated workflow to convert GIF files to PNG format when changes are detected
  - Triggers on pull requests and pushes to main for files in gen_* directories  
  - Uses ImageMagick to extract first frame of GIFs and save as PNGs in malmons_APNG subdirectories
  - Handles edge cases like first commits and missing previous revisions

  ## Features
  - **Smart file detection**: Only processes modified GIF files, not all files
  - **Automatic directory creation**: Creates malmons_APNG subdirectories as needed
  - **Robust error handling**: Handles first commits and missing git history
  - **Clean commits**: Automatically commits generated PNGs back to the branch

  ## Test plan
  - [x] Tested workflow triggers correctly on GIF file changes
  - [x] Verified PNG files are generated in correct directories with proper naming
  - [x] Confirmed automated commits work correctly
  - [x] Validated edge case handling (first commit scenario)